### PR TITLE
Use version 0.0.0 for nightly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,11 +56,8 @@ jobs:
           run: |
               cmake --build --preset Debug
 
-
-
     create_release:
-        #needs: [test_packages]
-        needs: [build_packages]
+        needs: [test_packages]
         runs-on: ubuntu-22.04
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/stm32h735g-dk/CMakeLists.txt
+++ b/stm32h735g-dk/CMakeLists.txt
@@ -39,7 +39,7 @@ set(SLINT_STYLE "fluent-light")
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 set(SLINT_TARGET_ARCHITECTURE thumbv7em-none-eabihf)
-find_package(Slint 0.0.0)
+find_package(Slint)
 
 set(DEFAULT_SLINT_EMBED_RESOURCES embed-for-software-renderer)
 

--- a/stm32h735g-dk/CMakeLists.txt
+++ b/stm32h735g-dk/CMakeLists.txt
@@ -39,9 +39,7 @@ set(SLINT_STYLE "fluent-light")
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 set(SLINT_TARGET_ARCHITECTURE thumbv7em-none-eabihf)
-# Remove once 1.8.0 is out
-set(SLINT_USE_NIGHTLY_VERSION TRUE)
-find_package(Slint 1.8.0)
+find_package(Slint 0.0.0)
 
 set(DEFAULT_SLINT_EMBED_RESOURCES embed-for-software-renderer)
 

--- a/stm32h735g-dk/cmake/FindSlint.cmake
+++ b/stm32h735g-dk/cmake/FindSlint.cmake
@@ -19,7 +19,7 @@
 # is happening in an ESP-IDF cross-compilation environment and detect the architecture accordingly, otherwise
 # `${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}` is used.
 #
-# `SLINT_USE_NIGHTLY_VERSION`: When `find_package(Slint)` is called with a version, then this module will 
+# `SLINT_USE_NIGHTLY_VERSION`: When `find_package(Slint)` is called with a version, then this module will
 # attempt to download a pre-compiled binary from the nightly snapshot of Slint.
 
 find_package(Slint ${Slint_FIND_VERSION} QUIET CONFIG)
@@ -60,12 +60,15 @@ if (NOT DEFINED Slint_FIND_VERSION)
 endif()
 
 set(slint_version "${Slint_FIND_VERSION}")
-set(github_release "${slint_version}")
 
-if (SLINT_USE_NIGHTLY_VERSION)
-    set(github_release "nightly")
+if (slint_version VERSION_LESS_EQUAL 0.0.0)
+    set(SLINT_USE_NIGHTLY_VERSION TRUE)
     # Set this to instruct the slint-compiler download to use the same release
     set(SLINT_GITHUB_RELEASE "nightly" CACHE STRING "")
+    set(github_release "nightly")
+
+else()
+    set(github_release "${slint_version}")
 endif()
 
 set(prebuilt_archive_filename "Slint-cpp-${slint_version}-${SLINT_TARGET_ARCHITECTURE}.tar.gz")

--- a/stm32h735g-dk/cmake/FindSlint.cmake
+++ b/stm32h735g-dk/cmake/FindSlint.cmake
@@ -9,7 +9,7 @@
 # 1. First `find_package(Slint ... CONFIG ...)` is called, to locate any packages in the `CMAKE_PREFIX_PATH`.
 # 2. If that failed and if `find_package` was called with a `VERSION`, then this module will attempt to download
 #    a pre-compiled binary package for the specified Slint release, extract it into `${CMAKE_BINARY_DIR}/slint-prebuilt`,
-#    and make it available.
+#    and make it available. If version is unset, download the nightly release.
 #
 # The following variables may be set to affect the behaviour:
 #
@@ -18,9 +18,6 @@
 # STM32 ARM architectures, you'd set this to `thumbv7em-none-eabihf`. If not set, this module will attempt to detect if compilation
 # is happening in an ESP-IDF cross-compilation environment and detect the architecture accordingly, otherwise
 # `${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}` is used.
-#
-# `SLINT_USE_NIGHTLY_VERSION`: When `find_package(Slint)` is called with a version, then this module will
-# attempt to download a pre-compiled binary from the nightly snapshot of Slint.
 
 find_package(Slint ${Slint_FIND_VERSION} QUIET CONFIG)
 if (TARGET Slint::Slint)
@@ -56,17 +53,9 @@ if (NOT SLINT_TARGET_ARCHITECTURE)
 endif()
 
 if (NOT DEFINED Slint_FIND_VERSION)
-    return()
-endif()
-
-set(slint_version "${Slint_FIND_VERSION}")
-
-if (Slint_FIND_VERSION VERSION_LESS_EQUAL 0.0.0)
-    set(SLINT_USE_NIGHTLY_VERSION TRUE)
     # Set this to instruct the slint-compiler download to use the same release
     set(SLINT_GITHUB_RELEASE "nightly" CACHE STRING "")
     set(github_release "nightly")
-
 else()
     set(github_release "${Slint_FIND_VERSION}")
 endif()

--- a/stm32h735g-dk/cmake/FindSlint.cmake
+++ b/stm32h735g-dk/cmake/FindSlint.cmake
@@ -61,17 +61,17 @@ endif()
 
 set(slint_version "${Slint_FIND_VERSION}")
 
-if (slint_version VERSION_LESS_EQUAL 0.0.0)
+if (Slint_FIND_VERSION VERSION_LESS_EQUAL 0.0.0)
     set(SLINT_USE_NIGHTLY_VERSION TRUE)
     # Set this to instruct the slint-compiler download to use the same release
     set(SLINT_GITHUB_RELEASE "nightly" CACHE STRING "")
     set(github_release "nightly")
 
 else()
-    set(github_release "${slint_version}")
+    set(github_release "${Slint_FIND_VERSION}")
 endif()
 
-set(prebuilt_archive_filename "Slint-cpp-${slint_version}-${SLINT_TARGET_ARCHITECTURE}.tar.gz")
+set(prebuilt_archive_filename "Slint-cpp-${github_release}-${SLINT_TARGET_ARCHITECTURE}.tar.gz")
 set(download_target_path "${CMAKE_BINARY_DIR}/slint-prebuilt/")
 set(download_url "https://github.com/slint-ui/slint/releases/download/${github_release}/${prebuilt_archive_filename}")
 

--- a/stm32h747i-disco/CM7/CMakeLists.txt
+++ b/stm32h747i-disco/CM7/CMakeLists.txt
@@ -41,7 +41,7 @@ set(SLINT_STYLE "fluent-light")
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake")
 
 set(SLINT_TARGET_ARCHITECTURE thumbv7em-none-eabihf)
-find_package(Slint 0.0.0)
+find_package(Slint)
 
 set(DEFAULT_SLINT_EMBED_RESOURCES embed-for-software-renderer)
 

--- a/stm32h747i-disco/CM7/CMakeLists.txt
+++ b/stm32h747i-disco/CM7/CMakeLists.txt
@@ -41,9 +41,7 @@ set(SLINT_STYLE "fluent-light")
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake")
 
 set(SLINT_TARGET_ARCHITECTURE thumbv7em-none-eabihf)
-# Remove once 1.8.0 is out
-set(SLINT_USE_NIGHTLY_VERSION TRUE)
-find_package(Slint 1.8.0)
+find_package(Slint 0.0.0)
 
 set(DEFAULT_SLINT_EMBED_RESOURCES embed-for-software-renderer)
 

--- a/stm32h747i-disco/cmake/FindSlint.cmake
+++ b/stm32h747i-disco/cmake/FindSlint.cmake
@@ -19,7 +19,7 @@
 # is happening in an ESP-IDF cross-compilation environment and detect the architecture accordingly, otherwise
 # `${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}` is used.
 #
-# `SLINT_USE_NIGHTLY_VERSION`: When `find_package(Slint)` is called with a version, then this module will 
+# `SLINT_USE_NIGHTLY_VERSION`: When `find_package(Slint)` is called with a version, then this module will
 # attempt to download a pre-compiled binary from the nightly snapshot of Slint.
 
 find_package(Slint ${Slint_FIND_VERSION} QUIET CONFIG)
@@ -60,12 +60,15 @@ if (NOT DEFINED Slint_FIND_VERSION)
 endif()
 
 set(slint_version "${Slint_FIND_VERSION}")
-set(github_release "${slint_version}")
 
-if (SLINT_USE_NIGHTLY_VERSION)
-    set(github_release "nightly")
+if (slint_version VERSION_LESS_EQUAL 0.0.0)
+    set(SLINT_USE_NIGHTLY_VERSION TRUE)
     # Set this to instruct the slint-compiler download to use the same release
     set(SLINT_GITHUB_RELEASE "nightly" CACHE STRING "")
+    set(github_release "nightly")
+
+else()
+    set(github_release "${slint_version}")
 endif()
 
 set(prebuilt_archive_filename "Slint-cpp-${slint_version}-${SLINT_TARGET_ARCHITECTURE}.tar.gz")

--- a/stm32h747i-disco/cmake/FindSlint.cmake
+++ b/stm32h747i-disco/cmake/FindSlint.cmake
@@ -59,19 +59,17 @@ if (NOT DEFINED Slint_FIND_VERSION)
     return()
 endif()
 
-set(slint_version "${Slint_FIND_VERSION}")
-
-if (slint_version VERSION_LESS_EQUAL 0.0.0)
+if (Slint_FIND_VERSION VERSION_LESS_EQUAL 0.0.0)
     set(SLINT_USE_NIGHTLY_VERSION TRUE)
     # Set this to instruct the slint-compiler download to use the same release
     set(SLINT_GITHUB_RELEASE "nightly" CACHE STRING "")
     set(github_release "nightly")
 
 else()
-    set(github_release "${slint_version}")
+    set(github_release "${Slint_FIND_VERSION}")
 endif()
 
-set(prebuilt_archive_filename "Slint-cpp-${slint_version}-${SLINT_TARGET_ARCHITECTURE}.tar.gz")
+set(prebuilt_archive_filename "Slint-cpp-${github_release}-${SLINT_TARGET_ARCHITECTURE}.tar.gz")
 set(download_target_path "${CMAKE_BINARY_DIR}/slint-prebuilt/")
 set(download_url "https://github.com/slint-ui/slint/releases/download/${github_release}/${prebuilt_archive_filename}")
 

--- a/stm32h747i-disco/cmake/FindSlint.cmake
+++ b/stm32h747i-disco/cmake/FindSlint.cmake
@@ -9,7 +9,7 @@
 # 1. First `find_package(Slint ... CONFIG ...)` is called, to locate any packages in the `CMAKE_PREFIX_PATH`.
 # 2. If that failed and if `find_package` was called with a `VERSION`, then this module will attempt to download
 #    a pre-compiled binary package for the specified Slint release, extract it into `${CMAKE_BINARY_DIR}/slint-prebuilt`,
-#    and make it available.
+#    and make it available. If version is unset, download the nightly release.
 #
 # The following variables may be set to affect the behaviour:
 #
@@ -18,9 +18,6 @@
 # STM32 ARM architectures, you'd set this to `thumbv7em-none-eabihf`. If not set, this module will attempt to detect if compilation
 # is happening in an ESP-IDF cross-compilation environment and detect the architecture accordingly, otherwise
 # `${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}` is used.
-#
-# `SLINT_USE_NIGHTLY_VERSION`: When `find_package(Slint)` is called with a version, then this module will
-# attempt to download a pre-compiled binary from the nightly snapshot of Slint.
 
 find_package(Slint ${Slint_FIND_VERSION} QUIET CONFIG)
 if (TARGET Slint::Slint)
@@ -56,15 +53,9 @@ if (NOT SLINT_TARGET_ARCHITECTURE)
 endif()
 
 if (NOT DEFINED Slint_FIND_VERSION)
-    return()
-endif()
-
-if (Slint_FIND_VERSION VERSION_LESS_EQUAL 0.0.0)
-    set(SLINT_USE_NIGHTLY_VERSION TRUE)
     # Set this to instruct the slint-compiler download to use the same release
     set(SLINT_GITHUB_RELEASE "nightly" CACHE STRING "")
     set(github_release "nightly")
-
 else()
     set(github_release "${Slint_FIND_VERSION}")
 endif()


### PR DESCRIPTION
So that we can easily replace the string in the release script